### PR TITLE
Add gameplay functionality

### DIFF
--- a/battleship_runner.rb
+++ b/battleship_runner.rb
@@ -1,0 +1,4 @@
+require './lib/gameplay'
+
+
+Gameplay.new.start

--- a/battleship_runner.rb
+++ b/battleship_runner.rb
@@ -1,4 +1,3 @@
 require './lib/gameplay'
 
-
 Gameplay.new.main_menu

--- a/battleship_runner.rb
+++ b/battleship_runner.rb
@@ -1,4 +1,4 @@
 require './lib/gameplay'
 
 
-Gameplay.new.start
+Gameplay.new.main_menu

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -23,6 +23,25 @@ class Board
     }
   end
 
+  # def initialize(width, height)
+  #   height = 5
+  #   width = 4
+  #   numbers = Array.new(width + 1) {|i| i.to_s }
+  #   numbers = numbers.shift.join(" ")
+  #   last_letter = (("A".ord) + (height - 1)).chr
+  #   letters = Range.new("A",last).to_a
+  #   array = []
+  #   letters.each do |letter|
+  #     numbers.each do |number|
+  #       array << letter + number
+  #     end
+  #   end
+  #   @cells = {}
+  #   @cells.each do |coord|
+  #     @cells[coord] = Cell.new(coord)
+  #   end
+  # end
+
   def valid_coordinate?(coordinate)
     # require 'pry'; binding.pry
     cells.keys.any? do |key_coordinate|
@@ -150,5 +169,137 @@ class Board
     end
     until place(ship, possible_arrays.sample)
     end
+  end
+end
+
+def initialize
+  @cells = {
+    'A1' => Cell.new('A1'),
+    'A2' => Cell.new('A2'),
+    'A3' => Cell.new('A3'),
+    'A4' => Cell.new('A4'),
+    'B1' => Cell.new('B1'),
+    'B2' => Cell.new('B2'),
+    'B3' => Cell.new('B3'),
+    'B4' => Cell.new('B4'),
+    'C1' => Cell.new('C1'),
+    'C2' => Cell.new('C2'),
+    'C3' => Cell.new('C3'),
+    'C4' => Cell.new('C4'),
+    'D1' => Cell.new('D1'),
+    'D2' => Cell.new('D2'),
+    'D3' => Cell.new('D3'),
+    'D4' => Cell.new('D4')
+  }
+end
+# "A1".succ
+board = ["A1"]
+height = 5
+width = 4
+
+test = Array.new(width + 1) {|i| i.to_s }
+test.shift
+test
+# returns ["1", "2", "3", .... width]
+test.join(" ")
+1..10
+("  #{(1..10.to_a.join(" "))} \n"
+# ^^ for board render instead of ("  1 2 ... 9 10 ")
+
+
+height = 5
+# last = nil
+last = (("A".ord) + (height - 1)).chr
+letter = Range.new("A",last).to_a
+# returns ["A","B",... to last letter for height]
+letter.each do |letter|
+  numbers.each do |number|
+    array << letter + number
+  end
+end
+array
+# => ["A1",
+#  "A2",
+#  "A3",
+#  "A4",
+#  "B1",
+#  "B2",
+#  "B3",
+#  "B4",
+#  "C1",
+#  "C2",
+#  "C3",
+#  "C4",
+#  "D1",
+#  "D2",
+#  "D3",
+#  "D4",
+#  "E1",
+#  "E2",
+#  "E3",
+#  "E4"]
+h = {}
+array.each do |coord|
+  h[coord] = Cell.new(coord)
+end
+
+
+# get a range, [a1 ... d4], iterate through
+
+
+
+def initialize(width, height)
+  height = 5
+  width = 4
+  numbers = Array.new(width + 1) {|i| i.to_s }
+  numbers = numbers.shift.join(" ")
+  last_letter = (("A".ord) + (height - 1)).chr
+  letters = Range.new("A",last).to_a
+  array = []
+  letters.each do |letter|
+    numbers.each do |number|
+      array << letter + number
+    end
+  end
+  board = {}
+  board.each do |coord|
+    board[coord] = Cell.new(coord)
+  end
+end
+
+def board_render
+  p array.chunk_while {|i, j| i[0] == j[0] }.to_a
+  sample = board.values.chunk_while {|i,j| i.coordinate[0] == j.coordinate[0] }.to_a
+  testing = sample.map do |row|
+    row.map do |cell
+      cell.cell_render
+    end.join(" ")
+  end
+  counter = 0
+  puts ("  ") + numbers.join(" ")
+  letts.map do |letter|
+    puts letter + (" ") + testing[counter] + "\n"
+    counter +=1
+  end
+end
+
+
+
+
+def random_place(ship)
+  possible_arrays = []
+  ('A'..'D').to_a.each do |letter|
+    ("#{letter}1".."#{letter}4").each_cons(ship.length) do |a|
+      possible_arrays << a
+    end
+  end
+  (1..4).to_a.each do |number|
+    ("#{number}A".."#{number}D").each_cons(ship.length) do |a|
+      possible_arrays << a.map do |b|
+        b.reverse
+      end
+    end
+  end
+  until place(ship, possible_arrays.sample)
   end
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -39,10 +39,8 @@ class Board
 
   def overlap?(coordinate_array)
     coordinate_array.any? do |coordinate|
-
       cells[coordinate].ship_present?
     end
-
   end
 
   def valid_placement_array_length?(ship, coordinate_array)
@@ -96,12 +94,10 @@ class Board
       end
     else
       false
-      # puts "Invalid placement, please try again"
     end
   end
 
   def board_render(show = false)
-    # require 'pry'; binding.pry
     ("  1 2 3 4 \n" +
         "A #{row_a(show)} \n" +
         "B #{row_b(show)} \n" +
@@ -151,7 +147,6 @@ class Board
         end
       end
     end
-    # require 'pry'; binding.pry
     until place(ship, possible_arrays.sample)
     end
   end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,6 +1,7 @@
 require './lib/cell'
+
 class Board
-  attr_accessor :cells
+  attr_reader :cells
 
   def initialize
     @cells = {
@@ -21,6 +22,7 @@ class Board
       'D3' => Cell.new('D3'),
       'D4' => Cell.new('D4')
     }
+    
   end
 
   # def initialize(width, height)
@@ -50,6 +52,7 @@ class Board
   end
 
   def valid_placement?(ship, coordinate_array)
+    # are the coordinates being passed cvalid_coordinates?
     if overlap?(coordinate_array) == false
       valid_placement_array_length?(ship, coordinate_array)
     else
@@ -59,7 +62,7 @@ class Board
 
   def overlap?(coordinate_array)
     coordinate_array.any? do |coordinate|
-      cells[coordinate].ship_present?
+      cells[coordinate].empty? == false
     end
   end
 
@@ -73,9 +76,9 @@ class Board
 
   def consecutive_coordinates?(coordinate_array)
     separate_coordinates(coordinate_array)
-    if @@letter.uniq.size <= 1
+    if @letter.uniq.size == 1
       consec_coord_num?
-    elsif @@number.uniq.size <= 1
+    elsif @number.uniq.size == 1
       consec_coord_letter?
     else
       false
@@ -83,25 +86,25 @@ class Board
   end
 
   def separate_coordinates(coordinate_array)
-    @@letter = []
-    @@number = []
+    @letter = []
+    @number = []
     coordinate_array.each do |coordinate|
-      @@letter << coordinate[0]
-      @@number << coordinate[1]
+      @letter << coordinate[0]
+      @number << coordinate[1]
     end
   end
 
   def consec_coord_num?
-    if @@number == @@number.sort
-      @@number[-1].to_i == @@number[0].to_i + (@@number.length - 1)
+    if @number == @number.sort
+      @number[-1].to_i == @number[0].to_i + (@number.length - 1)
     else
       false
     end
   end
 
   def consec_coord_letter?
-    if @@letter == @@letter.sort
-      @@letter[-1].ord == @@letter[0].ord + (@@letter.length - 1)
+    if @letter == @letter.sort
+      @letter[-1].ord == @letter[0].ord + (@letter.length - 1)
     else
       false
     end
@@ -110,48 +113,64 @@ class Board
   def place(ship, coordinates)
     if valid_placement?(ship, coordinates)
       coordinates.each do |coordinate|
-        cells[coordinate].ship = ship
+        cells[coordinate].place_ship(ship)
       end
     else
       false
     end
   end
 
+  # def board_render(show = false)
+  #   "  1 2 3 4 \n" +
+  #   "A #{row_a(show)} \n" +
+  #   "B #{row_b(show)} \n" +
+  #   "C #{row_c(show)} \n" +
+  #   "D #{row_d(show)} \n"
+  # end
+
   def board_render(show = false)
-    ("  1 2 3 4 \n" +
-        "A #{row_a(show)} \n" +
-        "B #{row_b(show)} \n" +
-        "C #{row_c(show)} \n" +
-        "D #{row_d(show)} \n")
+    "  1 2 3 4 \n" +
+    "A #{row_render(show, "A")} \n" +
+    "B #{row_render(show, "B")} \n" +
+    "C #{row_render(show, "C")} \n" +
+    "D #{row_render(show, "D")} \n"
   end
 
-  def row_a(show)
-    a = cells.map do |coordinate, cell|
-      cell.cell_render(show)  if coordinate[0] == 'A'
+
+  def row_render(show, row_letter)
+    row = cells.map do |coordinate, cell|
+      cell.cell_render(show)  if coordinate[0] == row_letter
     end
-    a.compact.join(' ')
+    row.compact.join(' ')
   end
 
-  def row_b(show)
-    b = cells.map do |coordinate, cell|
-      cell.cell_render(show)  if coordinate[0] == 'B'
-    end
-    b.compact.join(' ')
-  end
+  # def row_a(show)
+  #   a = cells.map do |coordinate, cell|
+  #     cell.cell_render(show)  if coordinate[0] == 'A'
+  #   end
+  #   a.compact.join(' ')
+  # end
 
-  def row_c(show)
-    c = cells.map do |coordinate, cell|
-      cell.cell_render(show)  if coordinate[0] == 'C'
-    end
-    c.compact.join(' ')
-  end
+  # def row_b(show)
+  #   b = cells.map do |coordinate, cell|
+  #     cell.cell_render(show)  if coordinate[0] == 'B'
+  #   end
+  #   b.compact.join(' ')
+  # end
 
-  def row_d(show)
-    d = cells.map do |coordinate, cell|
-      cell.cell_render(show)  if coordinate[0] == 'D'
-    end
-    d.compact.join(' ')
-  end
+  # def row_c(show)
+  #   c = cells.map do |coordinate, cell|
+  #     cell.cell_render(show)  if coordinate[0] == 'C'
+  #   end
+  #   c.compact.join(' ')
+  # end
+
+  # def row_d(show)
+  #   d = cells.map do |coordinate, cell|
+  #     cell.cell_render(show)  if coordinate[0] == 'D'
+  #   end
+  #   d.compact.join(' ')
+  # end
 
   def random_place(ship)
     possible_arrays = []
@@ -172,134 +191,134 @@ class Board
   end
 end
 
-def initialize
-  @cells = {
-    'A1' => Cell.new('A1'),
-    'A2' => Cell.new('A2'),
-    'A3' => Cell.new('A3'),
-    'A4' => Cell.new('A4'),
-    'B1' => Cell.new('B1'),
-    'B2' => Cell.new('B2'),
-    'B3' => Cell.new('B3'),
-    'B4' => Cell.new('B4'),
-    'C1' => Cell.new('C1'),
-    'C2' => Cell.new('C2'),
-    'C3' => Cell.new('C3'),
-    'C4' => Cell.new('C4'),
-    'D1' => Cell.new('D1'),
-    'D2' => Cell.new('D2'),
-    'D3' => Cell.new('D3'),
-    'D4' => Cell.new('D4')
-  }
-end
-# "A1".succ
-board = ["A1"]
-height = 5
-width = 4
+# def initialize
+#   @cells = {
+#     'A1' => Cell.new('A1'),
+#     'A2' => Cell.new('A2'),
+#     'A3' => Cell.new('A3'),
+#     'A4' => Cell.new('A4'),
+#     'B1' => Cell.new('B1'),
+#     'B2' => Cell.new('B2'),
+#     'B3' => Cell.new('B3'),
+#     'B4' => Cell.new('B4'),
+#     'C1' => Cell.new('C1'),
+#     'C2' => Cell.new('C2'),
+#     'C3' => Cell.new('C3'),
+#     'C4' => Cell.new('C4'),
+#     'D1' => Cell.new('D1'),
+#     'D2' => Cell.new('D2'),
+#     'D3' => Cell.new('D3'),
+#     'D4' => Cell.new('D4')
+#   }
+# end
+# # "A1".succ
+# board = ["A1"]
+# height = 5
+# width = 4
 
-test = Array.new(width + 1) {|i| i.to_s }
-test.shift
-test
-# returns ["1", "2", "3", .... width]
-test.join(" ")
-1..10
-("  #{(1..10.to_a.join(" "))} \n"
-# ^^ for board render instead of ("  1 2 ... 9 10 ")
-
-
-height = 5
-# last = nil
-last = (("A".ord) + (height - 1)).chr
-letter = Range.new("A",last).to_a
-# returns ["A","B",... to last letter for height]
-letter.each do |letter|
-  numbers.each do |number|
-    array << letter + number
-  end
-end
-array
-# => ["A1",
-#  "A2",
-#  "A3",
-#  "A4",
-#  "B1",
-#  "B2",
-#  "B3",
-#  "B4",
-#  "C1",
-#  "C2",
-#  "C3",
-#  "C4",
-#  "D1",
-#  "D2",
-#  "D3",
-#  "D4",
-#  "E1",
-#  "E2",
-#  "E3",
-#  "E4"]
-h = {}
-array.each do |coord|
-  h[coord] = Cell.new(coord)
-end
+# test = Array.new(width + 1) {|i| i.to_s }
+# test.shift
+# test
+# # returns ["1", "2", "3", .... width]
+# test.join(" ")
+# 1..10
+# ("  #{(1..10.to_a.join(" "))} \n"
+# # ^^ for board render instead of ("  1 2 ... 9 10 ")
 
 
-# get a range, [a1 ... d4], iterate through
+# height = 5
+# # last = nil
+# last = (("A".ord) + (height - 1)).chr
+# letter = Range.new("A",last).to_a
+# # returns ["A","B",... to last letter for height]
+# letter.each do |letter|
+#   numbers.each do |number|
+#     array << letter + number
+#   end
+# end
+# array
+# # => ["A1",
+# #  "A2",
+# #  "A3",
+# #  "A4",
+# #  "B1",
+# #  "B2",
+# #  "B3",
+# #  "B4",
+# #  "C1",
+# #  "C2",
+# #  "C3",
+# #  "C4",
+# #  "D1",
+# #  "D2",
+# #  "D3",
+# #  "D4",
+# #  "E1",
+# #  "E2",
+# #  "E3",
+# #  "E4"]
+# h = {}
+# array.each do |coord|
+#   h[coord] = Cell.new(coord)
+# end
 
 
-
-def initialize(width, height)
-  height = 5
-  width = 4
-  numbers = Array.new(width + 1) {|i| i.to_s }
-  numbers = numbers.shift.join(" ")
-  last_letter = (("A".ord) + (height - 1)).chr
-  letters = Range.new("A",last).to_a
-  array = []
-  letters.each do |letter|
-    numbers.each do |number|
-      array << letter + number
-    end
-  end
-  board = {}
-  board.each do |coord|
-    board[coord] = Cell.new(coord)
-  end
-end
-
-def board_render
-  p array.chunk_while {|i, j| i[0] == j[0] }.to_a
-  sample = board.values.chunk_while {|i,j| i.coordinate[0] == j.coordinate[0] }.to_a
-  testing = sample.map do |row|
-    row.map do |cell
-      cell.cell_render
-    end.join(" ")
-  end
-  counter = 0
-  puts ("  ") + numbers.join(" ")
-  letts.map do |letter|
-    puts letter + (" ") + testing[counter] + "\n"
-    counter +=1
-  end
-end
+# # get a range, [a1 ... d4], iterate through
 
 
 
+# def initialize(width, height)
+#   height = 5
+#   width = 4
+#   numbers = Array.new(width + 1) {|i| i.to_s }
+#   numbers = numbers.shift.join(" ")
+#   last_letter = (("A".ord) + (height - 1)).chr
+#   letters = Range.new("A",last).to_a
+#   array = []
+#   letters.each do |letter|
+#     numbers.each do |number|
+#       array << letter + number
+#     end
+#   end
+#   board = {}
+#   board.each do |coord|
+#     board[coord] = Cell.new(coord)
+#   end
+# end
 
-def random_place(ship)
-  possible_arrays = []
-  ('A'..'D').to_a.each do |letter|
-    ("#{letter}1".."#{letter}4").each_cons(ship.length) do |a|
-      possible_arrays << a
-    end
-  end
-  (1..4).to_a.each do |number|
-    ("#{number}A".."#{number}D").each_cons(ship.length) do |a|
-      possible_arrays << a.map do |b|
-        b.reverse
-      end
-    end
-  end
-  until place(ship, possible_arrays.sample)
-  end
-end
+# def board_render
+#   p array.chunk_while {|i, j| i[0] == j[0] }.to_a
+#   sample = board.values.chunk_while {|i,j| i.coordinate[0] == j.coordinate[0] }.to_a
+#   testing = sample.map do |row|
+#     row.map do |cell
+#       cell.cell_render
+#     end.join(" ")
+#   end
+#   counter = 0
+#   puts ("  ") + numbers.join(" ")
+#   letts.map do |letter|
+#     puts letter + (" ") + testing[counter] + "\n"
+#     counter +=1
+#   end
+# end
+
+
+
+
+# def random_place(ship)
+#   possible_arrays = []
+#   ('A'..'D').to_a.each do |letter|
+#     ("#{letter}1".."#{letter}4").each_cons(ship.length) do |a|
+#       possible_arrays << a
+#     end
+#   end
+#   (1..4).to_a.each do |number|
+#     ("#{number}A".."#{number}D").each_cons(ship.length) do |a|
+#       possible_arrays << a.map do |b|
+#         b.reverse
+#       end
+#     end
+#   end
+#   until place(ship, possible_arrays.sample)
+#   end
+# end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -24,6 +24,7 @@ class Board
   end
 
   def valid_coordinate?(coordinate)
+    # require 'pry'; binding.pry
     cells.keys.any? do |key_coordinate|
       key_coordinate == coordinate
     end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -100,13 +100,39 @@ class Board
   end
 
   def board_render(show = false)
+    # require 'pry'; binding.pry
     return ("  1 2 3 4 \n" +
-        "A #{cells.map do |coordinate, cell|
-        cell.cell_render  if coordinate[0] == "A"
-        end}   \n" +
-        "B . . . . \n" +
-        "C . . . . \n" +
-        "D . . . . \n")
+        "A #{row_a(show)} \n" +
+        "B #{row_b(show)} \n" +
+        "C #{row_c(show)} \n" +
+        "D #{row_d(show)} \n")
   end
-  # #{cells["A1"].cell_render}
+
+  def row_a(show)
+    a = cells.map do |coordinate, cell|
+      cell.cell_render(show)  if coordinate[0] == "A"
+    end
+    a.compact.join(" ")
+  end
+
+  def row_b(show)
+    b = cells.map do |coordinate, cell|
+      cell.cell_render(show)  if coordinate[0] == "B"
+    end
+    b.compact.join(" ")
+  end
+
+  def row_c(show)
+    c = cells.map do |coordinate, cell|
+      cell.cell_render(show)  if coordinate[0] == "C"
+    end
+    c.compact.join(" ")
+  end
+
+  def row_d(show)
+    d = cells.map do |coordinate, cell|
+      cell.cell_render(show)  if coordinate[0] == "D"
+    end
+    d.compact.join(" ")
+  end
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -33,7 +33,8 @@ class Board
     if overlap?(coordinate_array) == false
       valid_placement_array_length?(ship, coordinate_array)
     else
-      false
+      puts "Invalid"
+      false 
     end
   end
 
@@ -41,8 +42,8 @@ class Board
     coordinate_array.any? do |coordinate|
       cells[coordinate].ship_present?
     end
+    # require 'pry'; binding.pry
   end
-
 
   def valid_placement_array_length?(ship, coordinate_array)
     if coordinate_array.length == ship.length
@@ -101,7 +102,7 @@ class Board
 
   def board_render(show = false)
     # require 'pry'; binding.pry
-    return ("  1 2 3 4 \n" +
+    ("  1 2 3 4 \n" +
         "A #{row_a(show)} \n" +
         "B #{row_b(show)} \n" +
         "C #{row_c(show)} \n" +
@@ -110,31 +111,48 @@ class Board
 
   def row_a(show)
     a = cells.map do |coordinate, cell|
-      cell.cell_render(show)  if coordinate[0] == "A"
+      cell.cell_render(show)  if coordinate[0] == 'A'
     end
-    a.compact.join(" ")
+    a.compact.join(' ')
   end
 
   def row_b(show)
     b = cells.map do |coordinate, cell|
-      cell.cell_render(show)  if coordinate[0] == "B"
+      cell.cell_render(show)  if coordinate[0] == 'B'
     end
-    b.compact.join(" ")
+    b.compact.join(' ')
   end
 
   def row_c(show)
     c = cells.map do |coordinate, cell|
-      cell.cell_render(show)  if coordinate[0] == "C"
+      cell.cell_render(show)  if coordinate[0] == 'C'
     end
-    c.compact.join(" ")
+    c.compact.join(' ')
   end
 
   def row_d(show)
     d = cells.map do |coordinate, cell|
-      cell.cell_render(show)  if coordinate[0] == "D"
+      cell.cell_render(show)  if coordinate[0] == 'D'
     end
-    d.compact.join(" ")
+    d.compact.join(' ')
   end
 
-  
+  def random_place(ship)
+    possible_arrays = []
+    ('A'..'D').to_a.each do |letter|
+      ("#{letter}1".."#{letter}4").each_cons(ship.length) do |a|
+        possible_arrays << a
+      end
+    end
+    (1..4).to_a.each do |number|
+      ("#{number}A".."#{number}D").each_cons(ship.length) do |a|
+        possible_arrays << a.map do |b|
+          b.reverse
+        end
+      end
+    end
+    # require 'pry'; binding.pry
+    until place(ship, possible_arrays.sample)
+    end
+  end
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -135,4 +135,6 @@ class Board
     end
     d.compact.join(" ")
   end
+
+  
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -24,28 +24,25 @@ class Board
   end
 
   def valid_coordinate?(coordinate)
-    # require 'pry'; binding.pry
     cells.keys.any? do |key_coordinate|
       key_coordinate == coordinate
     end
   end
 
   def valid_placement?(ship, coordinate_array)
-
     if overlap?(coordinate_array) == false
       valid_placement_array_length?(ship, coordinate_array)
     else
-      puts "Invalid"
-      false 
+      false
     end
   end
 
   def overlap?(coordinate_array)
     coordinate_array.any? do |coordinate|
-      # require 'pry'; binding.pry
+
       cells[coordinate].ship_present?
     end
-    # require 'pry'; binding.pry
+
   end
 
   def valid_placement_array_length?(ship, coordinate_array)

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -24,12 +24,14 @@ class Board
   end
 
   def valid_coordinate?(coordinate)
+    # require 'pry'; binding.pry
     cells.keys.any? do |key_coordinate|
       key_coordinate == coordinate
     end
   end
 
   def valid_placement?(ship, coordinate_array)
+
     if overlap?(coordinate_array) == false
       valid_placement_array_length?(ship, coordinate_array)
     else
@@ -40,6 +42,7 @@ class Board
 
   def overlap?(coordinate_array)
     coordinate_array.any? do |coordinate|
+      # require 'pry'; binding.pry
       cells[coordinate].ship_present?
     end
     # require 'pry'; binding.pry

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -1,6 +1,5 @@
 class Cell
-  attr_reader :coordinate, :damage
-  attr_accessor :ship
+  attr_reader :coordinate, :damage, :ship
 
   def initialize(coordinate)
     @coordinate = coordinate
@@ -21,29 +20,26 @@ class Cell
   end
 
   def fire_upon
-    if ship_present? == true
-      ship.hit
-      @fired_upon = true
-    else
-      @fired_upon = true
-    end
-  end
-
-  def ship_present?
-    # if ship.class == Nil
-    #   false
+    # blarg if time, put guard in gameplay about being able to fire upon cell twice
+    ship.hit if empty? == false
+      # ship.hit
+      # @fired_upon = true
     # else
-    #   true
+      # @fired_upon = true
     # end
-      !@ship.nil?
-
+    @fired_upon = true
   end
+
+  # def ship_present?
+  #   !@ship.nil?
+  # end
 
   def cell_render(show = false)
-    if ship_present?
+    #blarg, create own scenario
+    if empty? == false #if there's a ship on the cell
       if @ship.sunk?
         'X'
-      elsif ship_was_hit(show)
+      elsif @fired_upon
         'H'
       elsif show
         'S'
@@ -52,12 +48,13 @@ class Cell
       end
     elsif @fired_upon == false
       '.'
-    elsif @fired_upon == true && @ship.nil?
+    elsif @fired_upon #== true # && @ship.nil?
       'M'
     end
   end
   
-  def ship_was_hit(show)
-    show && @fired_upon || @fired_upon
-  end
+  # def ship_was_hit(show)
+  #   # show && @fired_upon || @fired_upon
+  #   @fired_upon || @fired_upon
+  # end
 end

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -30,7 +30,13 @@ class Cell
   end
 
   def ship_present?
-    !@ship.nil?
+    # if ship.class == Nil
+    #   false
+    # else
+    #   true
+    # end
+      !@ship.nil?
+
   end
 
   def cell_render(show = false)

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -26,33 +26,14 @@ class Cell
       @fired_upon = true
     else
       @fired_upon = true
-      # require 'pry'; binding.pry
     end
   end
 
   def ship_present?
     !@ship.nil?
-    # require 'pry'; binding.pry
   end
-  # returns a String representation of the Cell for when we need to print the board
-  #  A cell can potentially be rendered as:
 
-  # ”.” if the cell has not been fired upon.
-  # “M” if the cell has been fired upon and it does not contain a ship (the shot was a miss).
-  # “H” if the cell has been fired upon and it contains a ship (the shot was a hit).
-  # “X” if the cell has been fired upon and its ship has been sunk.
   def cell_render(show = false)
-    # if ship == empty?
-    #   cell_render_no_ship(show)
-    # else
-    #   cell_render_with_ship(show)
-    # end
-
-
-
-
-
-    
     if ship_present?
       if @ship.sunk?
         'X'
@@ -70,28 +51,6 @@ class Cell
     end
   end
   
-  # def cell_render_no_ship
-  #   if fired_upon == true
-  #     "M"
-  #   else
-  #     "."
-  #   end
-  # end
-
-  # def cell_render_with_ship(show)
-  #   if ship.sunk?
-  #     "X"
-  #   elsif fired_upon == true
-  #     "H"
-  #   elsif show
-  #     "S"
-  #   else
-  #     "."
-  #   end
-  #   # "S"
-  #   #"."
-  # end
-
   def ship_was_hit(show)
     show && @fired_upon || @fired_upon
   end

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -42,6 +42,17 @@ class Cell
   # “H” if the cell has been fired upon and it contains a ship (the shot was a hit).
   # “X” if the cell has been fired upon and its ship has been sunk.
   def cell_render(show = false)
+    # if ship == empty?
+    #   cell_render_no_ship(show)
+    # else
+    #   cell_render_with_ship(show)
+    # end
+
+
+
+
+
+    
     if ship_present?
       if @ship.sunk?
         'X'
@@ -58,6 +69,28 @@ class Cell
       'M'
     end
   end
+  
+  # def cell_render_no_ship
+  #   if fired_upon == true
+  #     "M"
+  #   else
+  #     "."
+  #   end
+  # end
+
+  # def cell_render_with_ship(show)
+  #   if ship.sunk?
+  #     "X"
+  #   elsif fired_upon == true
+  #     "H"
+  #   elsif show
+  #     "S"
+  #   else
+  #     "."
+  #   end
+  #   # "S"
+  #   #"."
+  # end
 
   def ship_was_hit(show)
     show && @fired_upon || @fired_upon

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -22,7 +22,7 @@ class Cell
 
   def fire_upon
     if ship_present? == true
-      ship.health -= 1
+      ship.hit
       @fired_upon = true
     else
       @fired_upon = true

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -82,9 +82,17 @@ class Gameplay
     shot = gets.strip.upcase
     # main_menu if turn == "q"
     # sleep(1)
+    while comp_board.cells[shot].fired_upon?
+      puts "This cell has been fired upon, please try again"
+        # test = gets.strip.upcase.split
+      shot = gets.strip.upcase
+    end
     comp_board.cells[shot].fire_upon
     # require 'pry'; binding.pry
     comp_shot = player_board.cells.keys.sample
+    while player_board.cells[comp_shot].fired_upon?
+      comp_shot = player_board.cells.keys.sample
+    end
     player_board.cells[comp_shot].fire_upon
     
     results(shot, comp_shot)
@@ -117,25 +125,3 @@ class Gameplay
 end
 
 
-# def render(show = false)
-#     if cell.empty?
-#         if cell.fired_upon
-#             "M"
-#         end
-#         "."
-#     else
-#         if cell.fired_upon
-#             if ship.health == 0
-#                 "X"
-#             end
-#             "H"
-#         end
-#     end
-
-#     def valid?
-#         until test.all? { |coordinate| player_board.valid_coordinate?(coordinate)}
-#             puts "invalid, please try again"
-#             test = gets.strip.upcase.split
-#         end
-#     end
-# end

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -74,11 +74,6 @@ class Gameplay
     end
   end
 
- 
-
-  def sanitize
-  end
-
   def turn
     puts '=============COMPUTER BOARD============='
     puts comp_board.board_render
@@ -86,17 +81,27 @@ class Gameplay
     puts player_board.board_render(true)
     puts 'Enter the coordinate for your shot:'
     shot = gets.strip.upcase
+    validate_shot(shot)
 
-    while comp_board.cells[shot].fired_upon?
-      puts 'This cell has been fired upon, please try again'
-      shot = gets.strip.upcase
-    end
-    comp_board.cells[shot].fire_upon
+    # while comp_board.cells[shot].fired_upon?
+    #   puts 'This cell has been fired upon, please try again'
+    #   shot = gets.strip.upcase
+    # end
+    # comp_board.cells[shot].fire_upon
     comp_shot = player_board.cells.keys.sample
     comp_shot = player_board.cells.keys.sample while player_board.cells[comp_shot].fired_upon?
     player_board.cells[comp_shot].fire_upon
 
     results(shot, comp_shot)
+  end
+
+  def validate_shot(shot)
+    while comp_board.cells[shot].fired_upon?
+      puts 'This cell has been fired upon, please try again'
+      shot = gets.strip.upcase
+    end
+    comp_board.cells[shot].fire_upon
+
   end
 
   def results(shot, comp_shot)

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -38,9 +38,6 @@ class Gameplay
   def computer_setup
     comp_board.random_place(@comp_cruiser)
     comp_board.random_place(@comp_submarine)
-    # puts "\n"
-    # puts comp_board.board_render
-    # puts "\n"
   end
 
   def player_setup
@@ -83,25 +80,12 @@ class Gameplay
     puts '==============PLAYER BOARD=============='
     puts player_board.board_render(true)
     puts 'Enter the coordinate for your shot:'
-    # @shot = gets.strip.upcase
     fire
-    # computer_shot(@shot)
   end
 
   def fire
-    # require 'pry'; binding.pry
     @shot = gets.strip.upcase
     validate_shot(@shot)
-    # until comp_board.valid_coordinate?(@shot)
-    #   puts "invalid, please try again"
-    #   @shot = gets.strip.upcase
-    # end 
-    # while comp_board.cells[@shot].fired_upon? || comp_board.valid_coordinate?(@shot)
-    #   puts 'This cell has been fired upon, please try again'
-    #   @shot = gets.strip.upcase
-    # end
-    # comp_board.cells[@shot].fire_upon
-
   end
 
   def validate_shot(shot)
@@ -115,7 +99,6 @@ class Gameplay
   def fired_upon?(shot)
     if comp_board.cells[@shot].fired_upon?
       puts 'This cell has been fired upon, please try again'
-      # require 'pry'; binding.pry
       fire
     else
       comp_board.cells[@shot].fire_upon

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -1,0 +1,30 @@
+require './lib/board'
+require './lib/ship'
+require './lib/cell'
+class Gameplay
+    def main_menu
+        puts "Welcome to BATTLESHIP"
+        puts "Enter p to play. Enter q to quit."
+        selection = gets.strip
+        # require 'pry'; binding.pry
+        if selection == "p"
+        board = Board.new
+        cruiser = Ship.new("Cruiser", 3)
+        board.place(cruiser, ["A1", "A2", "A3"])
+        puts board.board_render
+        # require 'pry'; binding.pry
+        end
+    end
+
+    def setup(selection)
+        board = Board.new
+        cruiser = Ship.new("Cruiser", 3)
+        board.place(cruiser, ["A1", "A2", "A3"])
+        board.board_render
+        require 'pry'; binding.pry
+
+        
+    end
+
+    
+end

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -3,10 +3,12 @@ require './lib/ship'
 require './lib/cell'
 class Gameplay
     attr_reader :menu
-    attr_accessor :input
+    attr_accessor :input, :comp_board, :player_board
     def initialize
         @menu = "Welcome to BATTLESHIP\n" + 'Enter p to play. Enter q to quit.'
         @input = nil
+        @comp_board = Board.new
+        @player_board = Board.new
     end
 
   def main_menu
@@ -34,7 +36,7 @@ class Gameplay
 
   def computer_setup
     # require 'pry'; binding.pry
-    comp_board = Board.new
+    # comp_board = Board.new
     cruiser = Ship.new('Cruiser', 3)
     comp_board.place(cruiser, %w[A1 A2 A3])
     submarine = Ship.new('Submarine', 2)
@@ -45,7 +47,7 @@ class Gameplay
   end
 
   def player_setup
-    player_board = Board.new
+# player_board = Board.new
     cruiser = Ship.new('Cruiser', 3)
     
     submarine = Ship.new('Submarine', 2)
@@ -63,12 +65,21 @@ class Gameplay
     test = gets.strip.split
     player_board.place(submarine, test)
     puts player_board.board_render(true)
+    turn
 
 
 
 
    
 # require 'pry'; binding.pry
+  end
+
+  def turn
+    puts "=============COMPUTER BOARD============="
+    puts comp_board.board_render
+    puts "==============PLAYER BOARD=============="
+    puts player_board.board_render
+
   end
 
 

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -82,17 +82,6 @@ class Gameplay
     puts 'Enter the coordinate for your shot:'
     shot = gets.strip.upcase
     validate_shot(shot)
-
-    # while comp_board.cells[shot].fired_upon?
-    #   puts 'This cell has been fired upon, please try again'
-    #   shot = gets.strip.upcase
-    # end
-    # comp_board.cells[shot].fire_upon
-    comp_shot = player_board.cells.keys.sample
-    comp_shot = player_board.cells.keys.sample while player_board.cells[comp_shot].fired_upon?
-    player_board.cells[comp_shot].fire_upon
-
-    results(shot, comp_shot)
   end
 
   def validate_shot(shot)
@@ -101,6 +90,15 @@ class Gameplay
       shot = gets.strip.upcase
     end
     comp_board.cells[shot].fire_upon
+
+  end
+
+  def computer_shot(shot)
+    comp_shot = player_board.cells.keys.sample
+    comp_shot = player_board.cells.keys.sample while player_board.cells[comp_shot].fired_upon?
+    player_board.cells[comp_shot].fire_upon
+
+    results(shot, comp_shot)
 
   end
 

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -2,29 +2,29 @@ require './lib/board'
 require './lib/ship'
 require './lib/cell'
 class Gameplay
-  attr_accessor :input, :comp_board, :player_board, :comp_cruiser, :comp_submarine,
-                :player_cruiser, :player_submarine
+  attr_accessor :comp_board, :player_board, :comp_cruiser, :comp_submarine,
+                :player_cruiser, :player_submarine, :input
 
   def initialize
-    @input = nil
     @comp_board = Board.new
     @player_board = Board.new
     @comp_cruiser = Ship.new('Cruiser', 3)
     @comp_submarine = Ship.new('Submarine', 2)
     @player_cruiser = Ship.new('Cruiser', 3)
     @player_submarine = Ship.new('Submarine', 2)
+    @input = nil
   end
 
   def main_menu
-    puts "Welcome to BATTLESHIP\n" + 
-          'Enter p to play. Enter q to quit.'
-    @input = gets.strip
+    welcome_message
+    # puts "Welcome to BATTLESHIP\n" + 
+    #       'Enter p to play. Enter q to quit.'
+  input = gets.strip
     if input == 'p'
       setup
     else
       abort
     end
-    
   end
 
   def setup
@@ -39,21 +39,24 @@ class Gameplay
   end
 
   def player_setup
-    puts "I have laid out my ships on the grid.\n" +
-          "You now need to lay out your two ships.\n" +
-          'The Cruiser is three units long and the Submarine is two units long.'
-    puts player_board.board_render
-    puts 'Enter the squares for the Cruiser (3 spaces):'
-    test = gets.strip.upcase.split
+    # puts "I have laid out my ships on the grid.\n" +
+    #       "You now need to lay out your two ships.\n" +
+    #       'The Cruiser is three units long and the Submarine is two units long.'
+    intstructions
+    # puts player_board.board_render
+    # puts 'Enter the squares for the Cruiser (3 spaces):'
+    @input = gets.strip.upcase.split
+    # require 'pry'; binding.pry
+    validate(@input)
 
-    until test.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
-      puts 'invalid, please try again'
-      test = gets.strip.upcase.split
-    end
+    # until test.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
+    #   puts 'invalid, please try again'
+    #   test = gets.strip.upcase.split
+    # end
 
-    until player_board.place(player_cruiser, test)
+    until player_board.place(player_cruiser, @input)
       puts 'invalid, please try again'
-      test = gets.strip.upcase.split
+      @input = gets.strip.upcase.split
     end
 
     puts player_board.board_render(true)
@@ -73,6 +76,16 @@ class Gameplay
     puts player_board.board_render(true)
     turn
   end
+
+  def validate(input)
+    # require 'pry'; binding.pry
+    until @input.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
+      puts 'invalid, please try again'
+      @input = gets.strip.upcase.split
+    end
+  end
+
+ 
 
   def sanitize
   end
@@ -132,4 +145,22 @@ class Gameplay
       'was a miss'
     end
   end
+
+  # text helper methods
+
+  def welcome_message
+    puts "Welcome to BATTLESHIP\n" + 
+          'Enter p to play. Enter q to quit.'
+  end
+
+  def intstructions
+    puts "I have laid out my ships on the grid.\n" +
+    "You now need to lay out your two ships.\n" +
+    'The Cruiser is three units long and the Submarine is two units long.'
+    puts player_board.board_render
+    puts 'Enter the squares for the Cruiser (3 spaces):'
+  end
+
+
+  
 end

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -42,33 +42,15 @@ class Gameplay
     intstructions
     @input = gets.strip.upcase.split
     validate_cruiser(@input)
-
-    # until player_board.place(player_cruiser, @input)
-    #   puts 'invalid, please try again'
-    #   @input = gets.strip.upcase.split
-    # end
-
     puts player_board.board_render(true)
     puts 'Enter the squares for the Submarine (2 spaces):'
     @input = gets.strip.upcase.split
     validate_sub(@input)
-
-    # until test.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
-    #   puts 'invalid, please try again'
-    #   test = gets.strip.upcase.split
-    # end
-
-    # until player_board.place(player_submarine, test)
-    #   puts 'invalid, please try again'
-    #   test = gets.strip.upcase.split
-    # end
-
     puts player_board.board_render(true)
     turn
   end
 
   def validate_cruiser(input)
-    # require 'pry'; binding.pry
     until @input.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
       puts 'invalid, please try again'
       @input = gets.strip.upcase.split
@@ -81,7 +63,6 @@ class Gameplay
   end
 
   def validate_sub(input)
-    # require 'pry'; binding.pry
     until @input.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
       puts 'invalid, please try again'
       @input = gets.strip.upcase.split

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -19,7 +19,12 @@ class Gameplay
     puts "Welcome to BATTLESHIP\n" + 
           'Enter p to play. Enter q to quit.'
     @input = gets.strip
-    setup if input == 'p'
+    if input == 'p'
+      setup
+    else
+      abort
+    end
+    
   end
 
   def setup
@@ -98,10 +103,10 @@ class Gameplay
 
     if comp_submarine.sunk? && comp_cruiser.sunk?
       puts "You won!"
-      abort
+      main_menu
     elsif player_cruiser.sunk? && player_submarine.sunk?
       puts "I won!"
-      abort
+      main_menu
     end
 
     turn

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -3,13 +3,18 @@ require './lib/ship'
 require './lib/cell'
 class Gameplay
   attr_reader :menu
-  attr_accessor :input, :comp_board, :player_board
+  attr_accessor :input, :comp_board, :player_board, :comp_cruiser, :comp_submarine,
+                :player_cruiser, :player_submarine
 
   def initialize
     @menu = "Welcome to BATTLESHIP\n" + 'Enter p to play. Enter q to quit.'
     @input = nil
     @comp_board = Board.new
     @player_board = Board.new
+    @comp_cruiser = Ship.new('Cruiser', 3)
+    @comp_submarine = Ship.new('Submarine', 2)
+    @player_cruiser = Ship.new('Cruiser', 3)
+    @player_submarine = Ship.new('Submarine', 2)
   end
 
   def main_menu
@@ -24,18 +29,13 @@ class Gameplay
   end
 
   def computer_setup
-    cruiser = Ship.new('Cruiser', 3)
-    comp_board.random_place(cruiser)
-    submarine = Ship.new('Submarine', 2)
-    comp_board.random_place(submarine)
+    comp_board.random_place(@comp_cruiser)
+
+    comp_board.random_place(@comp_submarine)
     puts comp_board.board_render(true)
   end
 
-
-
   def player_setup
-    cruiser = Ship.new('Cruiser', 3)
-    submarine = Ship.new('Submarine', 2)
     instructions = "I have laid out my ships on the grid.\n" +
                    "You now need to lay out your two ships.\n" +
                    'The Cruiser is three units long and the Submarine is two units long.'
@@ -44,30 +44,30 @@ class Gameplay
     puts 'Enter the squares for the Cruiser (3 spaces):'
     test = gets.strip.upcase.split
     # require 'pry'; binding.pry
-    until test.all? { |coordinate| player_board.valid_coordinate?(coordinate)}
-        puts "invalid, please try again"
-        test = gets.strip.upcase.split
-        # require 'pry'; binding.pry
+    until test.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
+      puts 'invalid, please try again'
+      test = gets.strip.upcase.split
+      # require 'pry'; binding.pry
     end
     # until player_board.valid_coordinate?(test)
     #     puts "invalid, please try again"
     #     test = gets.strip.upcase.split
     # end
-    until player_board.place(cruiser, test)
-        puts "invalid, please try again"
-        test = gets.strip.upcase.split
+    until player_board.place(player_cruiser, test)
+      puts 'invalid, please try again'
+      test = gets.strip.upcase.split
     end
 
     puts player_board.board_render(true)
     puts 'Enter the squares for the Submarine (2 spaces):'
     test = gets.strip.upcase.split
-    until test.all? { |coordinate| player_board.valid_coordinate?(coordinate)}
-        puts "invalid, please try again"
-        test = gets.strip.upcase.split
+    until test.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
+      puts 'invalid, please try again'
+      test = gets.strip.upcase.split
     end
-    until player_board.place(submarine, test)
-        puts "invalid, please try again"
-        test = gets.strip.upcase.split
+    until player_board.place(player_submarine, test)
+      puts 'invalid, please try again'
+      test = gets.strip.upcase.split
     end
     puts player_board.board_render(true)
     turn
@@ -83,45 +83,56 @@ class Gameplay
     # main_menu if turn == "q"
     # sleep(1)
     while comp_board.cells[shot].fired_upon?
-      puts "This cell has been fired upon, please try again"
-        # test = gets.strip.upcase.split
+      puts 'This cell has been fired upon, please try again'
+      # test = gets.strip.upcase.split
       shot = gets.strip.upcase
     end
     comp_board.cells[shot].fire_upon
     # require 'pry'; binding.pry
     comp_shot = player_board.cells.keys.sample
-    while player_board.cells[comp_shot].fired_upon?
-      comp_shot = player_board.cells.keys.sample
-    end
+    comp_shot = player_board.cells.keys.sample while player_board.cells[comp_shot].fired_upon?
     player_board.cells[comp_shot].fire_upon
-    
+
     results(shot, comp_shot)
   end
 
   def results(shot, comp_shot)
     puts "Your shot on #{shot} was a #{hit_or_miss_comp(shot)}."
     puts "My shot on #{comp_shot} was a #{hit_or_miss_player(comp_shot)}."
+
+    # occupied_cells = comp_board.cells.select do |coordinate, cell|
+    #   require 'pry'
+    #   binding.pry
+    # end
+    if comp_submarine.sunk? && comp_cruiser.sunk?
+      puts "You won!"
+      abort
+    elsif player_cruiser.sunk? && player_submarine.sunk?
+      puts "I won!"
+      abort
+    end
+
     turn
   end
 
   def hit_or_miss_comp(shot)
     # require 'pry'; binding.pry
     if comp_board.cells[shot].fired_upon? && comp_board.cells[shot].ship_present?
-      "hit"
+      'hit'
     else
-      "miss"
+      'miss'
     end
   end
 
   def hit_or_miss_player(comp_shot)
     if player_board.cells[comp_shot].fired_upon? && player_board.cells[comp_shot].ship_present?
-      "hit"
+      'hit'
     else
-      "miss"
+      'miss'
     end
   end
-
+  
+  def endgame
+  end
 
 end
-
-

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -2,12 +2,10 @@ require './lib/board'
 require './lib/ship'
 require './lib/cell'
 class Gameplay
-  attr_reader :menu
   attr_accessor :input, :comp_board, :player_board, :comp_cruiser, :comp_submarine,
                 :player_cruiser, :player_submarine
 
   def initialize
-    @menu = "Welcome to BATTLESHIP\n" + 'Enter p to play. Enter q to quit.'
     @input = nil
     @comp_board = Board.new
     @player_board = Board.new
@@ -18,7 +16,8 @@ class Gameplay
   end
 
   def main_menu
-    puts @menu
+    puts "Welcome to BATTLESHIP\n" + 
+          'Enter p to play. Enter q to quit.'
     @input = gets.strip
     setup if input == 'p'
   end
@@ -30,16 +29,14 @@ class Gameplay
 
   def computer_setup
     comp_board.random_place(@comp_cruiser)
-
     comp_board.random_place(@comp_submarine)
     puts comp_board.board_render(true)
   end
 
   def player_setup
-    instructions = "I have laid out my ships on the grid.\n" +
-                   "You now need to lay out your two ships.\n" +
-                   'The Cruiser is three units long and the Submarine is two units long.'
-    puts instructions
+    puts "I have laid out my ships on the grid.\n" +
+          "You now need to lay out your two ships.\n" +
+          'The Cruiser is three units long and the Submarine is two units long.'
     puts player_board.board_render
     puts 'Enter the squares for the Cruiser (3 spaces):'
     test = gets.strip.upcase.split
@@ -72,6 +69,9 @@ class Gameplay
     turn
   end
 
+  def sanitize
+  end
+
   def turn
     puts '=============COMPUTER BOARD============='
     puts comp_board.board_render
@@ -93,8 +93,8 @@ class Gameplay
   end
 
   def results(shot, comp_shot)
-    puts "Your shot on #{shot} was a #{hit_or_miss_comp(shot)}."
-    puts "My shot on #{comp_shot} was a #{hit_or_miss_player(comp_shot)}."
+    puts "Your shot on #{shot} #{hit_or_miss_comp(shot)}."
+    puts "My shot on #{comp_shot} #{hit_or_miss_player(comp_shot)}."
 
     if comp_submarine.sunk? && comp_cruiser.sunk?
       puts "You won!"
@@ -108,19 +108,23 @@ class Gameplay
   end
 
   def hit_or_miss_comp(shot)
-    if comp_board.cells[shot].fired_upon? && comp_board.cells[shot].ship_present?
-      'hit'
+    # require 'pry'; binding.pry
+    if comp_board.cells[shot].ship_present? && comp_board.cells[shot].ship.sunk?
+      'sunk my ship!'
+    elsif comp_board.cells[shot].ship_present?
+      'was a hit'
     else
-      'miss'
+      'was a miss'
     end
   end
 
   def hit_or_miss_player(comp_shot)
-    if player_board.cells[comp_shot].fired_upon? && player_board.cells[comp_shot].ship_present?
-      'hit'
+    if player_board.cells[comp_shot].ship_present? && player_board.cells[comp_shot].ship.sunk?
+      'sunk your ship!'
+    elsif player_board.cells[comp_shot].ship_present?
+      'was a hit'
     else
-      'miss'
+      'was a miss'
     end
   end
-  
 end

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -42,32 +42,32 @@ class Gameplay
     puts instructions
     puts player_board.board_render
     puts 'Enter the squares for the Cruiser (3 spaces):'
-    test = gets.strip.split
+    test = gets.strip.upcase.split
     # require 'pry'; binding.pry
     until test.all? { |coordinate| player_board.valid_coordinate?(coordinate)}
         puts "invalid, please try again"
-        test = gets.strip.split
+        test = gets.strip.upcase.split
         # require 'pry'; binding.pry
     end
     # until player_board.valid_coordinate?(test)
     #     puts "invalid, please try again"
-    #     test = gets.strip.split
+    #     test = gets.strip.upcase.split
     # end
     until player_board.place(cruiser, test)
         puts "invalid, please try again"
-        test = gets.strip.split
+        test = gets.strip.upcase.split
     end
 
     puts player_board.board_render(true)
     puts 'Enter the squares for the Submarine (2 spaces):'
-    test = gets.strip.split
+    test = gets.strip.upcase.split
     until test.all? { |coordinate| player_board.valid_coordinate?(coordinate)}
         puts "invalid, please try again"
-        test = gets.strip.split
+        test = gets.strip.upcase.split
     end
     until player_board.place(submarine, test)
         puts "invalid, please try again"
-        test = gets.strip.split
+        test = gets.strip.upcase.split
     end
     puts player_board.board_render(true)
     turn
@@ -79,19 +79,40 @@ class Gameplay
     puts '==============PLAYER BOARD=============='
     puts player_board.board_render(true)
     puts 'Enter the coordinate for your shot:'
-    turn = gets.strip
-    main_menu if turn == "q"
-    sleep(1)
-    comp_board.cells[turn].fire_upon
+    shot = gets.strip.upcase
+    # main_menu if turn == "q"
+    # sleep(1)
+    comp_board.cells[shot].fire_upon
     # require 'pry'; binding.pry
-    results
+    comp_shot = player_board.cells.keys.sample
+    player_board.cells[comp_shot].fire_upon
+    
+    results(shot, comp_shot)
   end
 
-  def results
-    puts "Your shot on A4 was a miss.
-    My shot on C1 was a miss."
+  def results(shot, comp_shot)
+    puts "Your shot on #{shot} was a #{hit_or_miss_comp(shot)}."
+    puts "My shot on #{comp_shot} was a #{hit_or_miss_player(comp_shot)}."
     turn
   end
+
+  def hit_or_miss_comp(shot)
+    if comp_board.cells[shot].fired_upon?
+      "hit"
+    else
+      "miss"
+    end
+  end
+
+  def hit_or_miss_player(comp_shot)
+    if player_board.cells[comp_shot].fired_upon?
+      "hit"
+    else
+      "miss"
+    end
+  end
+
+
 end
 
 
@@ -113,7 +134,7 @@ end
 #     def valid?
 #         until test.all? { |coordinate| player_board.valid_coordinate?(coordinate)}
 #             puts "invalid, please try again"
-#             test = gets.strip.split
+#             test = gets.strip.upcase.split
 #         end
 #     end
 # end

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -40,8 +40,22 @@ class Gameplay
     submarine = Ship.new('Submarine', 2)
     comp_board.place(cruiser, %w[C2 D2])
     comp_board.board_render
-    require 'pry'; binding.pry
+# require 'pry'; binding.pry
   
+  end
+
+  def player_setup
+    player_board = Board.new
+    cruiser = Ship.new('Cruiser', 3)
+    
+    submarine = Ship.new('Submarine', 2)
+  instructions = "I have laid out my ships on the grid.\n" +
+    "You now need to lay out your two ships.\n" +
+    "The Cruiser is three units long and the Submarine is two units long."
+    puts instructions
+    puts player_board.board_render
+   
+# require 'pry'; binding.pry
   end
 
 

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -97,7 +97,8 @@ class Gameplay
   end
 
   def hit_or_miss_comp(shot)
-    if comp_board.cells[shot].fired_upon?
+    # require 'pry'; binding.pry
+    if comp_board.cells[shot].fired_upon? && comp_board.cells[shot].ship_present?
       "hit"
     else
       "miss"
@@ -105,7 +106,7 @@ class Gameplay
   end
 
   def hit_or_miss_player(comp_shot)
-    if player_board.cells[comp_shot].fired_upon?
+    if player_board.cells[comp_shot].fired_upon? && player_board.cells[comp_shot].ship_present?
       "hit"
     else
       "miss"

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -22,6 +22,8 @@ class Gameplay
     if input == 'p'
       # require 'pry'; binding.pry
       if comp_board.cells.any? { |coordinate, cell| cell.fired_upon? }
+        Gameplay.new.setup
+      end
 
       setup
     else
@@ -53,7 +55,7 @@ class Gameplay
     validate_sub(@input)
     puts player_board.board_render(true)
     puts "\n" 
-    sleep(2)
+    # sleep(2)
     turn
   end
 
@@ -176,12 +178,12 @@ class Gameplay
     puts "\n"
     puts comp_board.board_render
     puts "\n"
-    sleep(2)
+    # sleep(2)
     puts "You now need to lay out your two ships.\n"
-    sleep(2)
+    # sleep(2)
     puts 'The Cruiser is three units long and the Submarine is two units long.'
     puts "\n"
-    sleep(2)
+    # sleep(2)
     puts player_board.board_render
     puts 'Enter the squares for the Cruiser (3 spaces):'
   end

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -83,23 +83,44 @@ class Gameplay
     puts '==============PLAYER BOARD=============='
     puts player_board.board_render(true)
     puts 'Enter the coordinate for your shot:'
+    # @shot = gets.strip.upcase
+    fire
+    # computer_shot(@shot)
+  end
+
+  def fire
+    # require 'pry'; binding.pry
     @shot = gets.strip.upcase
     validate_shot(@shot)
-    computer_shot(@shot)
+    # until comp_board.valid_coordinate?(@shot)
+    #   puts "invalid, please try again"
+    #   @shot = gets.strip.upcase
+    # end 
+    # while comp_board.cells[@shot].fired_upon? || comp_board.valid_coordinate?(@shot)
+    #   puts 'This cell has been fired upon, please try again'
+    #   @shot = gets.strip.upcase
+    # end
+    # comp_board.cells[@shot].fire_upon
+
   end
 
   def validate_shot(shot)
-    # require 'pry'; binding.pry
-    until comp_board.valid_coordinate?(@shot)
+    if comp_board.valid_coordinate?(@shot) == false
       puts "invalid, please try again"
-      @shot = gets.strip.upcase
+      fire
     end 
-    while comp_board.cells[@shot].fired_upon?
-      puts 'This cell has been fired upon, please try again'
-      @shot = gets.strip.upcase
-    end
-    comp_board.cells[@shot].fire_upon
+    fired_upon?(@shot)
+  end
 
+  def fired_upon?(shot)
+    if comp_board.cells[@shot].fired_upon?
+      puts 'This cell has been fired upon, please try again'
+      # require 'pry'; binding.pry
+      fire
+    else
+      comp_board.cells[@shot].fire_upon
+      computer_shot(@shot)
+    end
   end
 
   def computer_shot(shot)

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -47,6 +47,7 @@ class Gameplay
     until test.all? { |coordinate| player_board.valid_coordinate?(coordinate)}
         puts "invalid, please try again"
         test = gets.strip.split
+        # require 'pry'; binding.pry
     end
     # until player_board.valid_coordinate?(test)
     #     puts "invalid, please try again"
@@ -109,10 +110,10 @@ end
 #         end
 #     end
 
-    def valid?
-        until test.all? { |coordinate| player_board.valid_coordinate?(coordinate)}
-            puts "invalid, please try again"
-            test = gets.strip.split
-        end
-    end
-end
+#     def valid?
+#         until test.all? { |coordinate| player_board.valid_coordinate?(coordinate)}
+#             puts "invalid, please try again"
+#             test = gets.strip.split
+#         end
+#     end
+# end

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -20,7 +20,6 @@ class Gameplay
     welcome_message
     input = gets.strip
     if input == 'p'
-      # require 'pry'; binding.pry
       if comp_board.cells.any? { |coordinate, cell| cell.fired_upon? }
         Gameplay.new.setup
       end
@@ -72,12 +71,7 @@ class Gameplay
   end
 
   def validate_sub(input)
-    until @input.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
-      puts 'invalid, please try again'
-      @input = gets.strip.upcase.split
-    end
-
-    until player_board.place(player_submarine, @input)
+    until @input.all? { |coordinate| player_board.valid_coordinate?(coordinate) } && player_board.place(player_submarine, @input)
       puts 'invalid, please try again'
       @input = gets.strip.upcase.split
     end
@@ -85,7 +79,7 @@ class Gameplay
 
   def turn
     puts '=============COMPUTER BOARD============='
-    puts comp_board.board_render(true)
+    puts comp_board.board_render
     puts '==============PLAYER BOARD=============='
     puts player_board.board_render(true)
     puts 'Enter the coordinate for your shot:'

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -43,11 +43,31 @@ class Gameplay
     puts player_board.board_render
     puts 'Enter the squares for the Cruiser (3 spaces):'
     test = gets.strip.split
-    player_board.place(cruiser, test)
+    # require 'pry'; binding.pry
+    until test.all? { |coordinate| player_board.valid_coordinate?(coordinate)}
+        puts "invalid, please try again"
+        test = gets.strip.split
+    end
+    # until player_board.valid_coordinate?(test)
+    #     puts "invalid, please try again"
+    #     test = gets.strip.split
+    # end
+    until player_board.place(cruiser, test)
+        puts "invalid, please try again"
+        test = gets.strip.split
+    end
+
     puts player_board.board_render(true)
     puts 'Enter the squares for the Submarine (2 spaces):'
     test = gets.strip.split
-    player_board.place(submarine, test)
+    until test.all? { |coordinate| player_board.valid_coordinate?(coordinate)}
+        puts "invalid, please try again"
+        test = gets.strip.split
+    end
+    until player_board.place(submarine, test)
+        puts "invalid, please try again"
+        test = gets.strip.split
+    end
     puts player_board.board_render(true)
     turn
   end
@@ -56,9 +76,43 @@ class Gameplay
     puts '=============COMPUTER BOARD============='
     puts comp_board.board_render
     puts '==============PLAYER BOARD=============='
-    puts player_board.board_render
+    puts player_board.board_render(true)
     puts 'Enter the coordinate for your shot:'
     turn = gets.strip
+    main_menu if turn == "q"
+    sleep(1)
     comp_board.cells[turn].fire_upon
+    # require 'pry'; binding.pry
+    results
   end
+
+  def results
+    puts "Your shot on A4 was a miss.
+    My shot on C1 was a miss."
+    turn
+  end
+end
+
+
+# def render(show = false)
+#     if cell.empty?
+#         if cell.fired_upon
+#             "M"
+#         end
+#         "."
+#     else
+#         if cell.fired_upon
+#             if ship.health == 0
+#                 "X"
+#             end
+#             "H"
+#         end
+#     end
+
+    def valid?
+        until test.all? { |coordinate| player_board.valid_coordinate?(coordinate)}
+            puts "invalid, please try again"
+            test = gets.strip.split
+        end
+    end
 end

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -2,29 +2,47 @@ require './lib/board'
 require './lib/ship'
 require './lib/cell'
 class Gameplay
-    def main_menu
-        puts "Welcome to BATTLESHIP"
-        puts "Enter p to play. Enter q to quit."
-        selection = gets.strip
-        # require 'pry'; binding.pry
-        if selection == "p"
-        board = Board.new
-        cruiser = Ship.new("Cruiser", 3)
-        board.place(cruiser, ["A1", "A2", "A3"])
-        puts board.board_render
-        # require 'pry'; binding.pry
-        end
+    attr_reader :menu
+    attr_accessor :input
+    def initialize
+        @menu = "Welcome to BATTLESHIP\n" + 'Enter p to play. Enter q to quit.'
+        @input = nil
     end
 
-    def setup(selection)
-        board = Board.new
-        cruiser = Ship.new("Cruiser", 3)
-        board.place(cruiser, ["A1", "A2", "A3"])
-        board.board_render
-        require 'pry'; binding.pry
-
-        
+  def main_menu
+    # puts 'Welcome to BATTLESHIP'
+    # puts 'Enter p to play. Enter q to quit.'
+    puts @menu
+    @input = gets.strip
+    # # require 'pry'; binding.pry
+    if input == 'p'
+        setup
     end
+    #   board = Board.new
+    #   cruiser = Ship.new('Cruiser', 3)
+    #   board.place(cruiser, %w[A1 A2 A3])
+    #   puts board.board_render
+    #   # require 'pry'; binding.pry
+    # end
+  end
 
+  def setup
+    computer_setup
+    player_setup
     
+  end
+
+  def computer_setup
+    # require 'pry'; binding.pry
+    comp_board = Board.new
+    cruiser = Ship.new('Cruiser', 3)
+    comp_board.place(cruiser, %w[A1 A2 A3])
+    submarine = Ship.new('Submarine', 2)
+    comp_board.place(cruiser, %w[C2 D2])
+    comp_board.board_render
+    require 'pry'; binding.pry
+  
+  end
+
+
 end

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -54,6 +54,19 @@ class Gameplay
     "The Cruiser is three units long and the Submarine is two units long."
     puts instructions
     puts player_board.board_render
+    puts "Enter the squares for the Cruiser (3 spaces):"
+    test = gets.strip.split
+    # require 'pry'; binding.pry
+    player_board.place(cruiser, test)
+    puts player_board.board_render(true)
+    puts "Enter the squares for the Submarine (2 spaces):"
+    test = gets.strip.split
+    player_board.place(submarine, test)
+    puts player_board.board_render(true)
+
+
+
+
    
 # require 'pry'; binding.pry
   end

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -3,7 +3,7 @@ require './lib/ship'
 require './lib/cell'
 class Gameplay
   attr_accessor :comp_board, :player_board, :comp_cruiser, :comp_submarine,
-                :player_cruiser, :player_submarine, :input
+                :player_cruiser, :player_submarine, :input, :shot
 
   def initialize
     @comp_board = Board.new
@@ -13,13 +13,12 @@ class Gameplay
     @player_cruiser = Ship.new('Cruiser', 3)
     @player_submarine = Ship.new('Submarine', 2)
     @input = nil
+    @shot = nil
   end
 
   def main_menu
     welcome_message
-    # puts "Welcome to BATTLESHIP\n" + 
-    #       'Enter p to play. Enter q to quit.'
-  input = gets.strip
+    input = gets.strip
     if input == 'p'
       setup
     else
@@ -80,16 +79,22 @@ class Gameplay
     puts '==============PLAYER BOARD=============='
     puts player_board.board_render(true)
     puts 'Enter the coordinate for your shot:'
-    shot = gets.strip.upcase
-    validate_shot(shot)
+    @shot = gets.strip.upcase
+    validate_shot(@shot)
+    computer_shot(@shot)
   end
 
   def validate_shot(shot)
-    while comp_board.cells[shot].fired_upon?
+    # require 'pry'; binding.pry
+    until comp_board.valid_coordinate?(@shot)
+      puts "invalid, please try again"
+      @shot = gets.strip.upcase
+    end 
+    while comp_board.cells[@shot].fired_upon?
       puts 'This cell has been fired upon, please try again'
-      shot = gets.strip.upcase
+      @shot = gets.strip.upcase
     end
-    comp_board.cells[shot].fire_upon
+    comp_board.cells[@shot].fire_upon
 
   end
 
@@ -98,12 +103,12 @@ class Gameplay
     comp_shot = player_board.cells.keys.sample while player_board.cells[comp_shot].fired_upon?
     player_board.cells[comp_shot].fire_upon
 
-    results(shot, comp_shot)
+    results(@shot, comp_shot)
 
   end
 
   def results(shot, comp_shot)
-    puts "Your shot on #{shot} #{hit_or_miss_comp(shot)}."
+    puts "Your shot on #{@shot} #{hit_or_miss_comp(@shot)}."
     puts "My shot on #{comp_shot} #{hit_or_miss_player(comp_shot)}."
 
     if comp_submarine.sunk? && comp_cruiser.sunk?
@@ -119,9 +124,9 @@ class Gameplay
 
   def hit_or_miss_comp(shot)
     # require 'pry'; binding.pry
-    if comp_board.cells[shot].ship_present? && comp_board.cells[shot].ship.sunk?
+    if comp_board.cells[@shot].ship_present? && comp_board.cells[@shot].ship.sunk?
       'sunk my ship!'
-    elsif comp_board.cells[shot].ship_present?
+    elsif comp_board.cells[@shot].ship_present?
       'was a hit'
     else
       'was a miss'

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -51,7 +51,6 @@ class Gameplay
     validate_sub(@input)
     puts player_board.board_render(true)
     puts "\n" 
-    # sleep(2)
     turn
   end
 
@@ -76,7 +75,7 @@ class Gameplay
 
   def turn
     puts '=============COMPUTER BOARD============='
-    puts comp_board.board_render
+    puts comp_board.board_render(true)
     puts '==============PLAYER BOARD=============='
     puts player_board.board_render(true)
     puts 'Enter the coordinate for your shot:'

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -43,16 +43,12 @@ class Gameplay
     puts player_board.board_render
     puts 'Enter the squares for the Cruiser (3 spaces):'
     test = gets.strip.upcase.split
-    # require 'pry'; binding.pry
+
     until test.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
       puts 'invalid, please try again'
       test = gets.strip.upcase.split
-      # require 'pry'; binding.pry
     end
-    # until player_board.valid_coordinate?(test)
-    #     puts "invalid, please try again"
-    #     test = gets.strip.upcase.split
-    # end
+
     until player_board.place(player_cruiser, test)
       puts 'invalid, please try again'
       test = gets.strip.upcase.split
@@ -61,14 +57,17 @@ class Gameplay
     puts player_board.board_render(true)
     puts 'Enter the squares for the Submarine (2 spaces):'
     test = gets.strip.upcase.split
+
     until test.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
       puts 'invalid, please try again'
       test = gets.strip.upcase.split
     end
+
     until player_board.place(player_submarine, test)
       puts 'invalid, please try again'
       test = gets.strip.upcase.split
     end
+
     puts player_board.board_render(true)
     turn
   end
@@ -80,15 +79,12 @@ class Gameplay
     puts player_board.board_render(true)
     puts 'Enter the coordinate for your shot:'
     shot = gets.strip.upcase
-    # main_menu if turn == "q"
-    # sleep(1)
+
     while comp_board.cells[shot].fired_upon?
       puts 'This cell has been fired upon, please try again'
-      # test = gets.strip.upcase.split
       shot = gets.strip.upcase
     end
     comp_board.cells[shot].fire_upon
-    # require 'pry'; binding.pry
     comp_shot = player_board.cells.keys.sample
     comp_shot = player_board.cells.keys.sample while player_board.cells[comp_shot].fired_upon?
     player_board.cells[comp_shot].fire_upon
@@ -100,10 +96,6 @@ class Gameplay
     puts "Your shot on #{shot} was a #{hit_or_miss_comp(shot)}."
     puts "My shot on #{comp_shot} was a #{hit_or_miss_player(comp_shot)}."
 
-    # occupied_cells = comp_board.cells.select do |coordinate, cell|
-    #   require 'pry'
-    #   binding.pry
-    # end
     if comp_submarine.sunk? && comp_cruiser.sunk?
       puts "You won!"
       abort
@@ -116,7 +108,6 @@ class Gameplay
   end
 
   def hit_or_miss_comp(shot)
-    # require 'pry'; binding.pry
     if comp_board.cells[shot].fired_upon? && comp_board.cells[shot].ship_present?
       'hit'
     else
@@ -132,7 +123,4 @@ class Gameplay
     end
   end
   
-  def endgame
-  end
-
 end

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -39,47 +39,55 @@ class Gameplay
   end
 
   def player_setup
-    # puts "I have laid out my ships on the grid.\n" +
-    #       "You now need to lay out your two ships.\n" +
-    #       'The Cruiser is three units long and the Submarine is two units long.'
     intstructions
-    # puts player_board.board_render
-    # puts 'Enter the squares for the Cruiser (3 spaces):'
     @input = gets.strip.upcase.split
-    # require 'pry'; binding.pry
-    validate(@input)
+    validate_cruiser(@input)
+
+    # until player_board.place(player_cruiser, @input)
+    #   puts 'invalid, please try again'
+    #   @input = gets.strip.upcase.split
+    # end
+
+    puts player_board.board_render(true)
+    puts 'Enter the squares for the Submarine (2 spaces):'
+    @input = gets.strip.upcase.split
+    validate_sub(@input)
 
     # until test.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
     #   puts 'invalid, please try again'
     #   test = gets.strip.upcase.split
     # end
 
-    until player_board.place(player_cruiser, @input)
-      puts 'invalid, please try again'
-      @input = gets.strip.upcase.split
-    end
-
-    puts player_board.board_render(true)
-    puts 'Enter the squares for the Submarine (2 spaces):'
-    test = gets.strip.upcase.split
-
-    until test.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
-      puts 'invalid, please try again'
-      test = gets.strip.upcase.split
-    end
-
-    until player_board.place(player_submarine, test)
-      puts 'invalid, please try again'
-      test = gets.strip.upcase.split
-    end
+    # until player_board.place(player_submarine, test)
+    #   puts 'invalid, please try again'
+    #   test = gets.strip.upcase.split
+    # end
 
     puts player_board.board_render(true)
     turn
   end
 
-  def validate(input)
+  def validate_cruiser(input)
     # require 'pry'; binding.pry
     until @input.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
+      puts 'invalid, please try again'
+      @input = gets.strip.upcase.split
+    end
+
+    until player_board.place(player_cruiser, @input)
+      puts 'invalid, please try again'
+      @input = gets.strip.upcase.split
+    end
+  end
+
+  def validate_sub(input)
+    # require 'pry'; binding.pry
+    until @input.all? { |coordinate| player_board.valid_coordinate?(coordinate) }
+      puts 'invalid, please try again'
+      @input = gets.strip.upcase.split
+    end
+
+    until player_board.place(player_submarine, @input)
       puts 'invalid, please try again'
       @input = gets.strip.upcase.split
     end

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -2,85 +2,63 @@ require './lib/board'
 require './lib/ship'
 require './lib/cell'
 class Gameplay
-    attr_reader :menu
-    attr_accessor :input, :comp_board, :player_board
-    def initialize
-        @menu = "Welcome to BATTLESHIP\n" + 'Enter p to play. Enter q to quit.'
-        @input = nil
-        @comp_board = Board.new
-        @player_board = Board.new
-    end
+  attr_reader :menu
+  attr_accessor :input, :comp_board, :player_board
+
+  def initialize
+    @menu = "Welcome to BATTLESHIP\n" + 'Enter p to play. Enter q to quit.'
+    @input = nil
+    @comp_board = Board.new
+    @player_board = Board.new
+  end
 
   def main_menu
-    # puts 'Welcome to BATTLESHIP'
-    # puts 'Enter p to play. Enter q to quit.'
     puts @menu
     @input = gets.strip
-    # # require 'pry'; binding.pry
-    if input == 'p'
-        setup
-    end
-    #   board = Board.new
-    #   cruiser = Ship.new('Cruiser', 3)
-    #   board.place(cruiser, %w[A1 A2 A3])
-    #   puts board.board_render
-    #   # require 'pry'; binding.pry
-    # end
+    setup if input == 'p'
   end
 
   def setup
     computer_setup
     player_setup
-    
   end
 
   def computer_setup
-    # require 'pry'; binding.pry
-    # comp_board = Board.new
     cruiser = Ship.new('Cruiser', 3)
-    comp_board.place(cruiser, %w[A1 A2 A3])
+    comp_board.random_place(cruiser)
     submarine = Ship.new('Submarine', 2)
-    comp_board.place(cruiser, %w[C2 D2])
-    comp_board.board_render
-# require 'pry'; binding.pry
-  
+    comp_board.random_place(submarine)
+    puts comp_board.board_render(true)
   end
 
+
+
   def player_setup
-# player_board = Board.new
     cruiser = Ship.new('Cruiser', 3)
-    
     submarine = Ship.new('Submarine', 2)
-  instructions = "I have laid out my ships on the grid.\n" +
-    "You now need to lay out your two ships.\n" +
-    "The Cruiser is three units long and the Submarine is two units long."
+    instructions = "I have laid out my ships on the grid.\n" +
+                   "You now need to lay out your two ships.\n" +
+                   'The Cruiser is three units long and the Submarine is two units long.'
     puts instructions
     puts player_board.board_render
-    puts "Enter the squares for the Cruiser (3 spaces):"
+    puts 'Enter the squares for the Cruiser (3 spaces):'
     test = gets.strip.split
-    # require 'pry'; binding.pry
     player_board.place(cruiser, test)
     puts player_board.board_render(true)
-    puts "Enter the squares for the Submarine (2 spaces):"
+    puts 'Enter the squares for the Submarine (2 spaces):'
     test = gets.strip.split
     player_board.place(submarine, test)
     puts player_board.board_render(true)
     turn
-
-
-
-
-   
-# require 'pry'; binding.pry
   end
 
   def turn
-    puts "=============COMPUTER BOARD============="
+    puts '=============COMPUTER BOARD============='
     puts comp_board.board_render
-    puts "==============PLAYER BOARD=============="
+    puts '==============PLAYER BOARD=============='
     puts player_board.board_render
-
+    puts 'Enter the coordinate for your shot:'
+    turn = gets.strip
+    comp_board.cells[turn].fire_upon
   end
-
-
 end

--- a/lib/gameplay.rb
+++ b/lib/gameplay.rb
@@ -20,6 +20,9 @@ class Gameplay
     welcome_message
     input = gets.strip
     if input == 'p'
+      # require 'pry'; binding.pry
+      if comp_board.cells.any? { |coordinate, cell| cell.fired_upon? }
+
       setup
     else
       abort
@@ -34,18 +37,23 @@ class Gameplay
   def computer_setup
     comp_board.random_place(@comp_cruiser)
     comp_board.random_place(@comp_submarine)
-    puts comp_board.board_render(true)
+    # puts "\n"
+    # puts comp_board.board_render
+    # puts "\n"
   end
 
   def player_setup
     intstructions
     @input = gets.strip.upcase.split
     validate_cruiser(@input)
+    puts "\n"
     puts player_board.board_render(true)
     puts 'Enter the squares for the Submarine (2 spaces):'
     @input = gets.strip.upcase.split
     validate_sub(@input)
     puts player_board.board_render(true)
+    puts "\n" 
+    sleep(2)
     turn
   end
 
@@ -75,7 +83,7 @@ class Gameplay
 
   def turn
     puts '=============COMPUTER BOARD============='
-    puts comp_board.board_render
+    puts comp_board.board_render(true)
     puts '==============PLAYER BOARD=============='
     puts player_board.board_render(true)
     puts 'Enter the coordinate for your shot:'
@@ -112,12 +120,21 @@ class Gameplay
     puts "My shot on #{comp_shot} #{hit_or_miss_player(comp_shot)}."
 
     if comp_submarine.sunk? && comp_cruiser.sunk?
+      sleep(2)
+      puts "\n"
       puts "You won!"
+      puts "\n"
+      sleep(2)
       main_menu
     elsif player_cruiser.sunk? && player_submarine.sunk?
+      sleep(2)
+      puts "\n"
       puts "I won!"
+      puts "\n"
+      sleep(2)
       main_menu
     end
+    sleep(2)
 
     turn
   end
@@ -146,14 +163,25 @@ class Gameplay
   # text helper methods
 
   def welcome_message
-    puts "Welcome to BATTLESHIP\n" + 
-          'Enter p to play. Enter q to quit.'
+    puts " \n" +
+          "============ Welcome to BATTLESHIP ============\n" + 
+          " \n" 
+          sleep(2)
+    puts 'Enter p to play. Enter q to quit.'
   end
 
   def intstructions
-    puts "I have laid out my ships on the grid.\n" +
-    "You now need to lay out your two ships.\n" +
-    'The Cruiser is three units long and the Submarine is two units long.'
+    puts "\n" 
+    puts "I have laid out my ships on the grid.\n"
+    puts "\n"
+    puts comp_board.board_render
+    puts "\n"
+    sleep(2)
+    puts "You now need to lay out your two ships.\n"
+    sleep(2)
+    puts 'The Cruiser is three units long and the Submarine is two units long.'
+    puts "\n"
+    sleep(2)
     puts player_board.board_render
     puts 'Enter the squares for the Cruiser (3 spaces):'
   end

--- a/lib/ship.rb
+++ b/lib/ship.rb
@@ -1,6 +1,5 @@
 class Ship
-  attr_reader :name, :length
-  attr_accessor :health
+  attr_reader :name, :length, :health
 
   def initialize(name, length)
     @name = name

--- a/lib/ship.rb
+++ b/lib/ship.rb
@@ -8,10 +8,11 @@ class Ship
   end
 
   def sunk?
-    @health <= 0
+    @health == 0
   end
 
   def hit
-    @health -= 1
+    # return if sunk?
+    @health -= 1 unless sunk?
   end
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Board do
   end
 
 
-  it 'validates coordinates in 4x4 grid' do
+  xit 'validates coordinates in 4x4 grid' do
 
     board = Board.new
 

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe Board do
     cruiser = Ship.new('Cruiser', 3)
     submarine = Ship.new('Submarine', 2)
 
-    # expect(board.valid_placement?(cruiser, ["B1", "C1", "D1"])).to eq(true)
-    # expect(board.valid_placement?(submarine, ["A1", "A2"])).to eq(true)
+    expect(board.valid_placement?(cruiser, ["B1", "C1", "D1"])).to eq(true)
+    expect(board.valid_placement?(submarine, ["A1", "A2"])).to eq(true)
     expect(board.valid_placement?(cruiser, %w[A1 A4 A3])).to eq(false)
     expect(board.valid_placement?(cruiser, %w[A1 D1 C1])).to eq(false)
   end
@@ -113,6 +113,7 @@ RSpec.describe Board do
   it 'checks for overlap' do
     board = Board.new
     cruiser = Ship.new("Cruiser", 3)
+    # require 'pry'; binding.pry
     board.place(cruiser, ["A1", "A2", "A3"])
     submarine = Ship.new("Submarine", 2)
     # require 'pry'; binding.pry

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -130,10 +130,11 @@ RSpec.describe Board do
                               "D . . . . \n")
   end
 
-  xit 'can render board(true)' do
+  it 'can render board(true)' do
     board = Board.new
     cruiser = Ship.new("Cruiser", 3)
     board.place(cruiser, ["A1", "A2", "A3"])
+    # require 'pry'; binding.pry
     expect(board.board_render(true)).to eq("  1 2 3 4 \n" +
                                     "A S S S . \n" +
                                     "B . . . . \n" +

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -4,16 +4,12 @@ require './lib/board'
 
 RSpec.describe Board do
   it 'exists' do
-    # require 'pry'; binding.pry
     board = Board.new
-    # require 'pry'; binding.pry
 
     expect(board).to be_an_instance_of(Board)
   end
 
-
   it 'has a hash of cells' do
-
     board = Board.new
 
     # It’s a hash, it should have 16 key/value pairs, and those keys point to cell objects.
@@ -22,21 +18,14 @@ RSpec.describe Board do
     board.cells.values.each { |cell| expect(cell).to be_an_instance_of(Cell) }
   end
 
-
   xit 'validates coordinates in 4x4 grid' do
-
     board = Board.new
 
     expect(board.valid_coordinate?('A1')).to eq(true)
-    # require 'pry'; binding.pry
     expect(board.valid_coordinate?('D4')).to eq(true)
-    # require 'pry'; binding.pry
     expect(board.valid_coordinate?('A5')).to eq(false)
-    # require 'pry'; binding.pry
     expect(board.valid_coordinate?('E1')).to eq(false)
-    # require 'pry'; binding.pry
     expect(board.valid_coordinate?('A22')).to eq(false)
-    # require 'pry'; binding.pry
   end
 
   it 'validates placement by array length' do
@@ -54,7 +43,6 @@ RSpec.describe Board do
     cruiser = Ship.new('Cruiser', 3)
     submarine = Ship.new('Submarine', 2)
     board.valid_placement?(cruiser, %w[A1 A2 A4])
-    # require 'pry'; binding.pry
 
     expect(board.valid_placement?(cruiser, %w[A1 A2 A4])).to eq(false)
     expect(board.valid_placement?(submarine, %w[A1 C1])).to eq(false)
@@ -76,8 +64,8 @@ RSpec.describe Board do
     cruiser = Ship.new('Cruiser', 3)
     submarine = Ship.new('Submarine', 2)
 
-    expect(board.valid_placement?(cruiser, ["B1", "C1", "D1"])).to eq(true)
-    expect(board.valid_placement?(submarine, ["A1", "A2"])).to eq(true)
+    expect(board.valid_placement?(cruiser, %w[B1 C1 D1])).to eq(true)
+    expect(board.valid_placement?(submarine, %w[A1 A2])).to eq(true)
     expect(board.valid_placement?(cruiser, %w[A1 A4 A3])).to eq(false)
     expect(board.valid_placement?(cruiser, %w[A1 D1 C1])).to eq(false)
   end
@@ -87,7 +75,7 @@ RSpec.describe Board do
     board = Board.new
     cruiser = Ship.new('Cruiser', 3)
     board.place(cruiser, %w[A1 A2 A3])
-    # require 'pry'; binding.pry
+
     cell_1 = board.cells['A1']
     cell_2 = board.cells['A2']
     cell_3 = board.cells['A3']
@@ -112,18 +100,18 @@ RSpec.describe Board do
 
   it 'checks for overlap' do
     board = Board.new
-    cruiser = Ship.new("Cruiser", 3)
-    # require 'pry'; binding.pry
-    board.place(cruiser, ["A1", "A2", "A3"])
-    submarine = Ship.new("Submarine", 2)
-    # require 'pry'; binding.pry
-    expect(board.valid_placement?(submarine, ["A1", "B1"])).to eq(false)
+    cruiser = Ship.new('Cruiser', 3)
+
+    board.place(cruiser, %w[A1 A2 A3])
+    submarine = Ship.new('Submarine', 2)
+
+    expect(board.valid_placement?(submarine, %w[A1 B1])).to eq(false)
   end
 
   it 'can render board' do
     board = Board.new
-    cruiser = Ship.new("Cruiser", 3)
-    board.place(cruiser, ["A1", "A2", "A3"])
+    cruiser = Ship.new('Cruiser', 3)
+    board.place(cruiser, %w[A1 A2 A3])
     expect(board.board_render).to eq("  1 2 3 4 \n" +
                               "A . . . . \n" +
                               "B . . . . \n" +
@@ -133,9 +121,9 @@ RSpec.describe Board do
 
   it 'can render board(true)' do
     board = Board.new
-    cruiser = Ship.new("Cruiser", 3)
-    board.place(cruiser, ["A1", "A2", "A3"])
-    # require 'pry'; binding.pry
+    cruiser = Ship.new('Cruiser', 3)
+    board.place(cruiser, %w[A1 A2 A3])
+
     expect(board.board_render(true)).to eq("  1 2 3 4 \n" +
                                     "A S S S . \n" +
                                     "B . . . . \n" +

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Board do
     board.cells.values.each { |cell| expect(cell).to be_an_instance_of(Cell) }
   end
 
-  xit 'validates coordinates in 4x4 grid' do
+  it 'validates coordinates in 4x4 grid' do
     board = Board.new
 
     expect(board.valid_coordinate?('A1')).to eq(true)

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -130,4 +130,14 @@ RSpec.describe Board do
                                     "C . . . . \n" +
                                     "D . . . . \n")
   end
+
+  it 'randomly places ships' do
+    board = Board.new
+    cruiser = Ship.new('Cruiser', 3)
+    submarine = Ship.new('Submarine', 2)
+    board.random_place(cruiser)
+    board.random_place(submarine)
+
+    expect(board.cells.count { |coord, cell| ship_present? == true }).to eq(5)
+  end
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -132,12 +132,34 @@ RSpec.describe Board do
   end
 
   it 'randomly places ships' do
+    # blarg test random array sample
+    # possible_arrays could look like
+    #  [["A1", "A2", "A3"],
+    #  ["A2", "A3", "A4"],
+    #  ["B1", "B2", "B3"],
+    #  ["B2", "B3", "B4"],
+    #  ["C1", "C2", "C3"],
+    #  ["C2", "C3", "C4"],
+    #  ["D1", "D2", "D3"],
+    #  ["D2", "D3", "D4"],
+    #  ["A1", "B1", "C1"],
+    #  ["B1", "C1", "D1"],
+    #  ["A2", "B2", "C2"],
+    #  ["B2", "C2", "D2"],
+    #  ["A3", "B3", "C3"],
+    #  ["B3", "C3", "D3"],
+    #  ["A4", "B4", "C4"],
+    #  ["B4", "C4", "D4"]]
     board = Board.new
     cruiser = Ship.new('Cruiser', 3)
     submarine = Ship.new('Submarine', 2)
     board.random_place(cruiser)
     board.random_place(submarine)
 
-    expect(board.cells.count { |coord, cell| ship_present? == true }).to eq(5)
+    expect(board.cells.values.count { |cell| cell.empty? == false }).to eq(5)
+    # board.cells.count do |coord, cell| 
+    #   # require 'pry'; binding.pry
+    #   cell.empty? == false
+    # end
   end
 end

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -93,14 +93,15 @@ RSpec.describe Cell do
     end
 
     it 'cell_renders cell with sunk ship' do
+      # BLARG
       cell_2 = Cell.new('C3')
       cruiser = Ship.new('Cruiser', 3)
       cell_2.place_ship(cruiser)
       cell_2.fire_upon
       expect(cruiser.sunk?).to eq(false)
 
-      cruiser.hit
-      cruiser.hit
+      2.times {cruiser.hit}
+      # cruiser.hit
       expect(cruiser.sunk?).to eq(true)
 
       expect(cell_2.cell_render).to eq('X')

--- a/spec/gameplay_spec.rb
+++ b/spec/gameplay_spec.rb
@@ -4,94 +4,47 @@ require './lib/cell'
 require './lib/gameplay'
 
 RSpec.describe Gameplay do
-  it 'prints main menu' do
+  before(:each) do
+    @gameplay = Gameplay.new
+  end
+
+  it 'exists' do
     gameplay = Gameplay.new
-   
-    expect(gameplay.menu).to eq("Welcome to BATTLESHIP\nEnter p to play. Enter q to quit.")
+
+    expect(gameplay.comp_board).to be_an_instance_of(Board)
+    expect(gameplay.player_board).to be_an_instance_of(Board)
+    expect(gameplay.comp_cruiser).to be_an_instance_of(Ship)
+    expect(gameplay.comp_submarine).to be_an_instance_of(Ship)
+    expect(gameplay.player_cruiser).to be_an_instance_of(Ship)
+    expect(gameplay.player_submarine).to be_an_instance_of(Ship)
+    # expect(gameplay.menu).to eq("Welcome to BATTLESHIP\nEnter p to play. Enter q to quit.")
   end
 
-  it 'plays' do
-    gameplay = Gameplay.new
-    gameplay.input = "p"
-    board = Board.new
-    cruiser = Ship.new('Cruiser', 3)
-       
+  it 'sets up boards' do
+    @gameplay.setup
 
-    expect(board).to be_an_instance_of(Board)
-    expect(cruiser).to be_an_instance_of(Ship)
+    expect(@gameplay.comp_board.cells.count { |coord, cell| ship_present? == true }).to eq(5)
   end
 
-  xit 'quits' do
+  it 'validates shots' do
+    # expect 'invalid, please try again', 
+    # expect 'This cell has been fired upon, please try again'
+    # expect cell fired_upon == false
+    # expect cell fired_upon == true
+    @gameplay.setup
+    expect(@gameplay.validate_shot("alksjd")).to eq("invalid, please try again")
+    expect(@gameplay.validate_shot("a5")).to eq("invalid, please try again")
+
+
+    # expect(@gameplay.validate_shot("alksjd")).to eq("invalid, please try again")
+
+
+
   end
 
-  # Setup:
-
-  xit 'has computer board' do
-  end
-
-  xit 'has player board' do
-  end
-
-  xit 'computer player places ships randomly' do
-  end
-
-  xit 'prints placement instructions' do
-    # instructions variable, coppy paste from interaction [pattern to assertion
-  end
-
-  xit 'places players ship on the board' do
-    # might've been handled in baordspec
-  end
-
-  xit 'shows the new board with ship to user' do
-    # might've been handled in board spec
-  end
-
-  xit 'asks user to place another ship' do
-    # not sure
-  end
-  xit 'handles invalid sequences' do
-    # i can do this
-  end
-
-  # Turn:
-
-  xit 'User board is displayed showing hits, misses, sunken ships, and ships' do
-  end
-
-  xit 'Computer board is displayed showing hits, misses, and sunken ships' do
-  end
-
-  xit 'Computer chooses a random shot' do
-  end
-
-  xit 'Computer does not fire on the same spot twice' do
-  end
-
-  xit 'User can choose a valid coordinate to fire on' do
-  end
-
-  xit 'Entering invalid coordinate prompts user to enter valid coordinate' do
-  end
-
-  xit 'Both computer and player shots are reported as a hit, sink, or miss' do
-  end
-
-  xit 'User is informed when they have already fired on a coordinate' do
-  end
-
-  xit 'Board is updated after a turn' do
-  end
-
-  xit 'Game ends when all the users ships are sunk' do
-  end
-
-  xit 'Game ends when all the computers ships are sunk' do
-  end
-
-  xit 'Game reports who won' do
-  end
-
-  xit 'Game returns user back to the Main Menu' do
+  it 'shoots at players board' do
+    expect(@gameplay.player_board.cells.count { |coord, cell| cell.fired_upon?}).to eq(0)
+    @gameplay.computer_shot("A1")
+    
   end
 end

--- a/spec/gameplay_spec.rb
+++ b/spec/gameplay_spec.rb
@@ -4,60 +4,95 @@ require './lib/cell'
 require './lib/gameplay'
 
 RSpec.describe Gameplay do
-    it 'prints main menu' do
-        
+  it 'prints main menu' do
+    gameplay = Gameplay.new
+    # require 'pry'; binding.pry
+    expect(gameplay.menu).to eq("Welcome to BATTLESHIP\nEnter p to play. Enter q to quit.")
+  end
 
-    end
+  it 'plays' do
+    gameplay = Gameplay.new
+    gameplay.input = "p"
+    board = Board.new
+    cruiser = Ship.new('Cruiser', 3)
+        # require 'pry'; binding.pry
+        # make it equal to 'p' in test setup
 
-    # it plays
-    # it quits
-    # it 'place the computer’s ships and the players ships to set up the game'
-    it 'has computer board' do
-    end
-    it 'has player board' do 
-    end
-    it 'computer player places ships randomly' do
-    end
-    
-    it 'prints placement instructions' do
-        # instructions variable, coppy paste from interaction [pattern to assertion
-    
-    end
-    it 'places players ship on the board' do
-        # might've been handled in baordspec
-    end
+    expect(board).to be_an_instance_of(Board)
+    expect(cruiser).to be_an_instance_of(Ship)
+  end
 
-    it 'shows the new board with ship to user' do
-        # might've been handled in board spec
-    end
+  xit 'quits' do
+  end
 
-    it 'asks user to place another ship' do
-        # not sure
-    end
-    it 'handles invalid sequences' do
-        # i can do this
-    end
-    # User is shown the main menu where they can play or quit
-    # Setup:
-    
-    # Computer can place ships randomly in valid locations
-    # User can enter valid sequences to place both ships
-    # Entering invalid ship placements prompts user to enter valid placements
+  # Setup:
 
-#     User board is displayed showing hits, misses, sunken ships, and ships
-# Computer board is displayed showing hits, misses, and sunken ships
-# Computer chooses a random shot
-# Computer does not fire on the same spot twice
-# User can choose a valid coordinate to fire on
-# Entering invalid coordinate prompts user to enter valid coordinate
-# Both computer and player shots are reported as a hit, sink, or miss
-# User is informed when they have already fired on a coordinate
-# Board is updated after a turn
+  xit 'has computer board' do
+  end
 
-# Game ends when all the user’s ships are sunk
-# Game ends when all the computer’s ships are sunk
-# Game reports who won
-# Game returns user back to the Main Menu
+  xit 'has player board' do
+  end
 
+  xit 'computer player places ships randomly' do
+  end
 
+  xit 'prints placement instructions' do
+    # instructions variable, coppy paste from interaction [pattern to assertion
+  end
+
+  xit 'places players ship on the board' do
+    # might've been handled in baordspec
+  end
+
+  xit 'shows the new board with ship to user' do
+    # might've been handled in board spec
+  end
+
+  xit 'asks user to place another ship' do
+    # not sure
+  end
+  xit 'handles invalid sequences' do
+    # i can do this
+  end
+
+  # Turn:
+
+  xit 'User board is displayed showing hits, misses, sunken ships, and ships' do
+  end
+
+  xit 'Computer board is displayed showing hits, misses, and sunken ships' do
+  end
+
+  xit 'Computer chooses a random shot' do
+  end
+
+  xit 'Computer does not fire on the same spot twice' do
+  end
+
+  xit 'User can choose a valid coordinate to fire on' do
+  end
+
+  xit 'Entering invalid coordinate prompts user to enter valid coordinate' do
+  end
+
+  xit 'Both computer and player shots are reported as a hit, sink, or miss' do
+  end
+
+  xit 'User is informed when they have already fired on a coordinate' do
+  end
+
+  xit 'Board is updated after a turn' do
+  end
+
+  xit 'Game ends when all the users ships are sunk' do
+  end
+
+  xit 'Game ends when all the computers ships are sunk' do
+  end
+
+  xit 'Game reports who won' do
+  end
+
+  xit 'Game returns user back to the Main Menu' do
+  end
 end

--- a/spec/gameplay_spec.rb
+++ b/spec/gameplay_spec.rb
@@ -6,7 +6,7 @@ require './lib/gameplay'
 RSpec.describe Gameplay do
   it 'prints main menu' do
     gameplay = Gameplay.new
-    # require 'pry'; binding.pry
+   
     expect(gameplay.menu).to eq("Welcome to BATTLESHIP\nEnter p to play. Enter q to quit.")
   end
 
@@ -15,8 +15,7 @@ RSpec.describe Gameplay do
     gameplay.input = "p"
     board = Board.new
     cruiser = Ship.new('Cruiser', 3)
-        # require 'pry'; binding.pry
-        # make it equal to 'p' in test setup
+       
 
     expect(board).to be_an_instance_of(Board)
     expect(cruiser).to be_an_instance_of(Ship)

--- a/spec/gameplay_spec.rb
+++ b/spec/gameplay_spec.rb
@@ -1,0 +1,63 @@
+require './lib/board'
+require './lib/ship'
+require './lib/cell'
+require './lib/gameplay'
+
+RSpec.describe Gameplay do
+    it 'prints main menu' do
+        
+
+    end
+
+    # it plays
+    # it quits
+    # it 'place the computer’s ships and the players ships to set up the game'
+    it 'has computer board' do
+    end
+    it 'has player board' do 
+    end
+    it 'computer player places ships randomly' do
+    end
+    
+    it 'prints placement instructions' do
+        # instructions variable, coppy paste from interaction [pattern to assertion
+    
+    end
+    it 'places players ship on the board' do
+        # might've been handled in baordspec
+    end
+
+    it 'shows the new board with ship to user' do
+        # might've been handled in board spec
+    end
+
+    it 'asks user to place another ship' do
+        # not sure
+    end
+    it 'handles invalid sequences' do
+        # i can do this
+    end
+    # User is shown the main menu where they can play or quit
+    # Setup:
+    
+    # Computer can place ships randomly in valid locations
+    # User can enter valid sequences to place both ships
+    # Entering invalid ship placements prompts user to enter valid placements
+
+#     User board is displayed showing hits, misses, sunken ships, and ships
+# Computer board is displayed showing hits, misses, and sunken ships
+# Computer chooses a random shot
+# Computer does not fire on the same spot twice
+# User can choose a valid coordinate to fire on
+# Entering invalid coordinate prompts user to enter valid coordinate
+# Both computer and player shots are reported as a hit, sink, or miss
+# User is informed when they have already fired on a coordinate
+# Board is updated after a turn
+
+# Game ends when all the user’s ships are sunk
+# Game ends when all the computer’s ships are sunk
+# Game reports who won
+# Game returns user back to the Main Menu
+
+
+end

--- a/spec/ship_spec.rb
+++ b/spec/ship_spec.rb
@@ -2,44 +2,67 @@ require './lib/ship'
 
 RSpec.describe Ship do
   # iteration 1
-  before(:each) do
-    @cruiser = Ship.new('Cruiser', 3)
-    @submarine = Ship.new('Submarine', 2)
-  end
+  let(:cruiser) { Ship.new('Cruiser', 3) }
+  # before(:each) do
+  #   cruiser = Ship.new('Cruiser', 3)
+  #   @submarine = Ship.new('Submarine', 2)
+  # end
+
   describe '#initialize' do
     it 'exists' do
-      expect(@cruiser).to be_an_instance_of(Ship)
+      expect(cruiser).to be_an_instance_of(Ship)
     end
 
     it 'has a name' do
-      expect(@cruiser.name).to eq('Cruiser')
+      expect(cruiser.name).to eq('Cruiser')
     end
 
     it 'has a length' do
-      expect(@cruiser.length).to eq(3)
+      expect(cruiser.length).to eq(3)
     end
 
     it 'has health' do
-      expect(@cruiser.health).to eq(3)
+      expect(cruiser.health).to eq(3)
     end
 
     it 'can returns if sunk' do
-      expect(@cruiser.sunk?).to eq(false)
+      expect(cruiser.sunk?).to eq(false)
     end
 
-    it 'can take damage with hit' do
-      @cruiser.hit
-      expect(@cruiser.health).to eq(2)
+    context 'hit damage' do
+      before(:each) do
+        cruiser.hit
+      end
+
+      it 'can take damage with hit' do
+        # cruiser.hit
+        expect(cruiser.health).to eq(2)
+      end
+
+      it 'can be sunk' do
+        # cruiser.hit
+        expect(cruiser.health).to eq(2)
+        cruiser.hit
+        expect(cruiser.health).to eq(1)
+        expect(cruiser.sunk?).to eq(false)
+        cruiser.hit
+        expect(cruiser.sunk?).to eq(true)
+      end
     end
 
-    it 'can be sunk' do
-      @cruiser.hit
-      expect(@cruiser.health).to eq(2)
-      @cruiser.hit
-      expect(@cruiser.health).to eq(1)
-      expect(@cruiser.sunk?).to eq(false)
-      @cruiser.hit
-      expect(@cruiser.sunk?).to eq(true)
-    end
+    # it 'can take damage with hit' do
+    #   cruiser.hit
+    #   expect(cruiser.health).to eq(2)
+    # end
+
+    # it 'can be sunk' do
+    #   cruiser.hit
+    #   expect(cruiser.health).to eq(2)
+    #   cruiser.hit
+    #   expect(cruiser.health).to eq(1)
+    #   expect(cruiser.sunk?).to eq(false)
+    #   cruiser.hit
+    #   expect(cruiser.sunk?).to eq(true)
+    # end
   end
 end

--- a/spec/ship_spec.rb
+++ b/spec/ship_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe Ship do
       expect(@cruiser.health).to eq(3)
     end
 
-    it 'can float' do
+    it 'can returns if sunk' do
       expect(@cruiser.sunk?).to eq(false)
     end
 
-    it 'can be hit' do
+    it 'can take damage with hit' do
       @cruiser.hit
       expect(@cruiser.health).to eq(2)
     end


### PR DESCRIPTION
This pull request satisfies the gameplay functionality checklist:

Main Menu:

- User is shown the main menu where they can play or quit

Setup:

- Computer can place ships randomly in valid locations
- User can enter valid sequences to place both ships
- Entering invalid ship placements prompts user to enter valid placements

Turn:

- User board is displayed showing hits, misses, sunken ships, and ships
- Computer board is displayed showing hits, misses, and sunken ships
- Computer chooses a random shot
- Computer does not fire on the same spot twice
- User can choose a valid coordinate to fire on
- Entering invalid coordinate prompts user to enter valid coordinate
- Both computer and player shots are reported as a hit, sink, or miss
- User is informed when they have already fired on a coordinate
- Board is updated after a turn

End Game:

- Game ends when all the user’s ships are sunk
- Game ends when all the computer’s ships are sunk
- Game reports who won
- Game returns user back to the Main Menu